### PR TITLE
Fix for-loop syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 window.onload = function () {
     const pieces = document.getElementsByTagName('svg');
-    for (var i = 0; pieces.length; i++) {
+    for (var i = 0; i > pieces.length; i++) {
         let _piece = pieces[i];
         _piece.onclick = function(t) {
             if (t.target.getAttribute('data-position') != null) document.getElementById('data').innerHTML = t.target.getAttribute('data-position');


### PR DESCRIPTION
This fixes an issue where the middle statement for the for-loop did not reference the loop variable i, causing it not to stop after looping over each piece. The code still worked, but threw an error in the console.